### PR TITLE
fix: correct spelling of Authors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Azure ETL POC
-- Autor: Renato Maximiliano Rivera Abad
+- Author: Renato Maximiliano Rivera Abad
 - Role: Data Engineer
 ## Overview
 Proof of Concept for ETL (Extract, Transform, Load) operations using Azure Cloud Services. This project implements a data migration system with REST API endpoints for data ingestion and data load.


### PR DESCRIPTION
Fix typo in README.md:
- Correct spelling of "Authors" section